### PR TITLE
Fix "file is used by other process" issue

### DIFF
--- a/CdIts.NetTopologySuite.IO.GeoPackage.FeatureReader/GeoPackageFeatureReader.cs
+++ b/CdIts.NetTopologySuite.IO.GeoPackage.FeatureReader/GeoPackageFeatureReader.cs
@@ -85,6 +85,7 @@ public class GeoPackageFeatureReader : IDisposable
 
     public void Dispose()
     {
+        SqliteConnection.ClearPool(_conn);
         _conn.Dispose();
     }
 }

--- a/CdIts.NetTopologySuite.IO.GeoPackage.FeatureReader/GeoPackageFeatureReader.cs
+++ b/CdIts.NetTopologySuite.IO.GeoPackage.FeatureReader/GeoPackageFeatureReader.cs
@@ -46,10 +46,10 @@ public class GeoPackageFeatureReader : IDisposable
         {
             try
             {
-                var line = data as IDictionary<string, object>;
-                var geoBytes = line[geoColumn] as byte[];
-                if (geoBytes is null)
+                if (data is not IDictionary<string, object> line || line[geoColumn] is not byte[] geoBytes)
+                {
                     throw new ArgumentNullException(geoColumn, "Geometry column is null");
+                }
                 var geo = reader.Read(geoBytes);
                 var attributes = line.Keys.Where(k => k != geoColumn).ToDictionary(k => k, k => line[k]);
                 return new Feature(geo, new AttributesTable(attributes));
@@ -61,7 +61,7 @@ public class GeoPackageFeatureReader : IDisposable
                     throw;
                 return null;
             }
-        }).Where(f => f != null).ToArray();
+        }).Where(f => f != null).Select(f => f!).ToArray();
     }
 
 

--- a/CdIts.NetTopologySuite.IO.GeoPackage.FeatureWriter/GeoPackageFeatureWriter.cs
+++ b/CdIts.NetTopologySuite.IO.GeoPackage.FeatureWriter/GeoPackageFeatureWriter.cs
@@ -34,28 +34,28 @@ public class GeoPackageFeatureWriter : IDisposable, IAsyncDisposable
         _conn.Open();
     }
 
-    public async Task CloseAsync(bool clearAllPools = false)
+    public async Task CloseAsync()
     {
+        SqliteConnection.ClearPool(_conn);
         await _conn.CloseAsync();
-        if(clearAllPools)
-            SqliteConnection.ClearAllPools();
     }
 
-    public void Close(bool clearAllPools = false)
+    public void Close()
     {
+        SqliteConnection.ClearPool(_conn);
         _conn.Close();
-        if(clearAllPools)
-            SqliteConnection.ClearAllPools();
     }
 
     public void Dispose()
     {
+        SqliteConnection.ClearPool(_conn);
         _conn.Dispose();
     }
 
 
     public async ValueTask DisposeAsync()
     {
+        SqliteConnection.ClearPool(_conn);
         await _conn.DisposeAsync();
     }
 

--- a/Tests/BasicTests.cs
+++ b/Tests/BasicTests.cs
@@ -22,12 +22,14 @@ public class BasicTests
         names.Should().NotContain("geometry");
         names.Should().Contain("id");
         names.Should().Contain("date");
+        var inUse = IsFileInUse("example.gpkg");
+        inUse.Should().BeFalse("file should not be used by an other process");
     }
 
     [Test]
     public async Task RoundtripTest()
     {
-        var writer = new GeoPackageFeatureWriter("test.gpkg");
+        using var writer = new GeoPackageFeatureWriter("test.gpkg");
         await writer.AddSrsAsync(25832, "ETRS89 / UTM zone 32N", "PROJCS[\"ETRS89 / UTM zone 32N\",GEOGCS[\"ETRS89\",DATUM[\"European_Terrestrial_Reference_System_1989\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY[\"EPSG\",\"6258\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4258\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",9],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"25832\"]]", "EPSG", 25832);
         var polygons = new List<Feature>();
         for (var i = 0; i < 10; i++)
@@ -73,7 +75,10 @@ public class BasicTests
         await writer.AddLayerAsync(polygons, "polygons");
         await writer.AddLayerAsync(lines, "lines");
         await writer.CloseAsync();
-        
+
+        var inUse = IsFileInUse("test.gpkg");
+        inUse.Should().BeFalse("file should not be used by an other process after writer is closed");
+
         var reader = GeoPackageFeatureReader.ReadGeoPackage("test.gpkg");
         reader.Count.Should().Be(2);
         var polygonLayer  = reader.FirstOrDefault(l => l.Info.TableName == "polygons");
@@ -89,6 +94,18 @@ public class BasicTests
         testFeature.Attributes["internalID"].Should().Be("X0");
         testFeature.Attributes["testDouble"].Should().BeOfType(typeof(double));
         testFeature.Attributes["date"].Should().BeOfType(typeof(string));
+    }
+
+    private static bool IsFileInUse(string filename)
+    {
+        try
+        {
+            using FileStream fs = File.Open(filename, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            return false;
+        }
+        catch (IOException) {
+            return true;
+        }
     }
 }
 


### PR DESCRIPTION
Hi,

I've encountered the problem where sqlite's connection pool hangs on to the connection and therefore keeps the file locked, in the FeatureWriter as well as the FeatureReader. I've tried to make as few changes as necessary to fix this, and removed the `clearAllPools` flag because it is not necessary anymore (and potentially dangerous to clear all connections).